### PR TITLE
Use plugin bat when installing on Windows

### DIFF
--- a/src/Elastic.Managed.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Managed.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -39,8 +39,8 @@ namespace Elastic.Managed.Ephemeral.Tasks
 	{
 		public abstract void Run(IEphemeralCluster<EphemeralClusterConfiguration> cluster);
 
-		protected static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
-		protected static string BinarySuffix => IsMono || Path.DirectorySeparatorChar == '/' ? "" : ".bat";
+		protected static bool IsWindows { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		protected static string BinarySuffix => IsWindows ? ".bat" : string.Empty;
 
 		protected static void DownloadFile(string from, string to)
 		{

--- a/src/Elastic.Managed.Ephemeral/Tasks/InstallationTasks/InstallPlugins.cs
+++ b/src/Elastic.Managed.Ephemeral/Tasks/InstallationTasks/InstallPlugins.cs
@@ -71,14 +71,14 @@ namespace Elastic.Managed.Ephemeral.Tasks.InstallationTasks
 				cluster.Writer?.WriteDiagnostic($"{{{nameof(Run)}}} attempting install [{plugin.SubProductName}] as it's not OOTB: {{{plugin.ShippedByDefaultAsOf}}} and valid for {v}: {{{plugin.IsValid(v)}}}");
 				//var installParameter = v.ReleaseState == ReleaseState.Released ? plugin.Moniker : UseHttpPluginLocation(cluster.Writer, fs, plugin, v);
 				var installParameter = UseHttpPluginLocation(cluster.Writer, fs, plugin, v);
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-					ExecuteBinary(cluster.ClusterConfiguration, cluster.Writer, "cmd", $"install elasticsearch plugin: {plugin.SubProductName}", $"/c CALL {fs.PluginBinary} install --batch", installParameter);
-				else
-				{
-					if (!Directory.Exists(fs.ConfigPath)) Directory.CreateDirectory(fs.ConfigPath);
-					ExecuteBinary(cluster.ClusterConfiguration, cluster.Writer, fs.PluginBinary, $"install elasticsearch plugin: {plugin.SubProductName}", "install --batch", installParameter);
-				}
-				
+				if (!Directory.Exists(fs.ConfigPath)) Directory.CreateDirectory(fs.ConfigPath);
+				ExecuteBinary(
+					cluster.ClusterConfiguration,
+					cluster.Writer,
+					fs.PluginBinary + BinarySuffix,
+					$"install elasticsearch plugin: {plugin.SubProductName}",
+					"install --batch", installParameter);
+
 				CopyConfigDirectoryToHomeCacheConfigDirectory(cluster, plugin);
 			}
 

--- a/src/Elastic.Managed.Ephemeral/Tasks/InstallationTasks/XPack/PathXPackInBatFile.cs
+++ b/src/Elastic.Managed.Ephemeral/Tasks/InstallationTasks/XPack/PathXPackInBatFile.cs
@@ -17,7 +17,7 @@ namespace Elastic.Managed.Ephemeral.Tasks.InstallationTasks.XPack
 			var v = config.Version;
 
 			if (v.Major != 5) return;
-			if (IsMono || Path.DirectorySeparatorChar == '/') return;
+			if (!IsWindows) return;
 
 			cluster.Writer?.WriteDiagnostic($"{{{nameof(PathXPackInBatFile)}}} patching x-pack .in.bat to accept CONF_DIR");
 			PatchPlugin(v, fileSystem);


### PR DESCRIPTION
This commit updates the InstallPlugins task to use the plugin batch file as the binary when installing plugins. Previously,
plugin installation used cmd as the binary, delegating to the batch file as an argument. This can cause issues where a plugin
writes warnings to stderr, such as ingest-attachmeent, which triggers the InstallPlugins task to throw an exception.

Remove IsMono property and replace with IsWindows property, using RuntimeInformation. Ultimately, this property is used to determine
the platform running on, specifically whether Windows or not.