### PR TITLE
Make sure we explicitly specify Xms and Mmx to 1g

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100"
+    "version": "5.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   }
 }

--- a/src/Elastic.Elasticsearch.Managed/ElasticsearchNode.cs
+++ b/src/Elastic.Elasticsearch.Managed/ElasticsearchNode.cs
@@ -47,12 +47,17 @@ namespace Elastic.Elasticsearch.Managed
 
 		private static Dictionary<string, string> EnvVars(NodeConfiguration config)
 		{
-			if (string.IsNullOrWhiteSpace(config.FileSystem.ConfigPath)) return null;
-			return new Dictionary<string, string>
+			var environmentVariables = new Dictionary<string, string>
 			{
-				{ config.FileSystem.ConfigEnvironmentVariableName, config.FileSystem.ConfigPath },
-				{"ES_HOME", config.FileSystem.ElasticsearchHome}
+				{"ES_JAVA_OPTS", "-Xms1g -Xmx1g"}
 			};
+			if (!string.IsNullOrWhiteSpace(config.FileSystem.ConfigPath))
+				environmentVariables.Add(config.FileSystem.ConfigEnvironmentVariableName, config.FileSystem.ConfigPath);
+
+			if (!string.IsNullOrWhiteSpace(config.FileSystem.ElasticsearchHome))
+				environmentVariables.Add("ES_HOME", config.FileSystem.ElasticsearchHome);
+
+			return environmentVariables;
 		}
 
 		/// <summary>


### PR DESCRIPTION
As of:

elastic/elasticsearch#65905

The default is dynamic and defaults to 4g on data nodes.
I finally had one too many IDE open to this becomming a problem on my
32gig laptop :)