### PR TITLE
Support ES_JAVA_HOME when version > 7.12.0

### DIFF
--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -178,7 +178,7 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks
 
 			if (result.ExitCode != 0)
 				throw new Exception(
-					$"Expected exit code 0 but recieved ({result.ExitCode}) while executing {description}: {command}");
+					$"Expected exit code 0 but received ({result.ExitCode}) while executing {description}: {command}");
 
 			var errorOut = result.ConsoleOut.Where(c => c.Error).ToList();
 			// this manifested when calling certgen on versions smaller then 5.2.0

--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -185,9 +185,9 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks
 			if (errorOut.Any() && config.Version < "5.2.0")
 				errorOut = errorOut.Where(e => !e.Line.Contains("No log4j2 configuration file found")).ToList();
 
-			if (errorOut.Any(e => !string.IsNullOrWhiteSpace(e.Line)) && (!binary.Contains("plugin") && !binary.Contains("cert")))
+			if (errorOut.Any(e => !string.IsNullOrWhiteSpace(e.Line) && !e.Line.Contains("usage of JAVA_HOME is deprecated")) && !binary.Contains("plugin") && !binary.Contains("cert"))
 				throw new Exception(
-					$"Recieved error out with exitCode ({result.ExitCode}) while executing {description}: {command}");
+					$"Received error out with exitCode ({result.ExitCode}) while executing {description}: {command}");
 
 			writer?.WriteDiagnostic(
 				$"{{{nameof(ExecuteBinary)}}} finished process [{description}] {{{result.ExitCode}}}");

--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/InstallationTasks/EnsureJavaHomeEnvironmentVariableIsSet.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/InstallationTasks/EnsureJavaHomeEnvironmentVariableIsSet.cs
@@ -13,8 +13,6 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks.InstallationTasks
 		public override void Run(IEphemeralCluster<EphemeralClusterConfiguration> cluster)
 		{
 			var fs = cluster.FileSystem;
-			var v = cluster.ClusterConfiguration.Version;
-			var a = cluster.ClusterConfiguration.Artifact;
 			
 			var java8Home = Environment.GetEnvironmentVariable("JAVA8_HOME");
 			if (cluster.ClusterConfiguration.Version < "6.0.0" && !string.IsNullOrWhiteSpace(java8Home))
@@ -23,30 +21,32 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks.InstallationTasks
 				Environment.SetEnvironmentVariable("JAVA_HOME", java8Home);
 				cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} Forcing [JAVA8_HOME] as [JAVA_HOME] since we are on Elasticsearch <6.0.0");
 			}
-			var javaHome = Environment.GetEnvironmentVariable("JAVA_HOME");
+
+			var envVarName = cluster.ClusterConfiguration.JavaHomeEnvironmentVariable;
+			var javaHome = Environment.GetEnvironmentVariable(envVarName);
+
 			//7.0.0 ships with its own JDK
 			if (cluster.ClusterConfiguration.Version < "7.0.0" && string.IsNullOrWhiteSpace(javaHome))
 			{
-				cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} [JAVA_HOME] is not SET exiting..");
-				throw new Exception("The elasticsearch bat files are resillient to JAVA_HOME not being set, however the shield tooling is not");
+				cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} [{envVarName}] is not SET exiting..");
+				throw new Exception("The elasticsearch bat files are resilient to JAVA_HOME not being set, however the shield tooling is not");
 			}
+			
 			var cachedEsHomeFolder = Path.Combine(fs.LocalFolder, cluster.GetCacheFolderName());
 			var jdkFolder = Path.Combine(cachedEsHomeFolder, "jdk");
 			if (Directory.Exists(jdkFolder))
 			{
 				//prefer bundled jdk
-				cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} [JAVA_HOME] is set to bundled jdk: {{{jdkFolder}}} ");
+				cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} [{envVarName}] is set to bundled jdk: {{{jdkFolder}}} ");
 				Environment.SetEnvironmentVariable("JAVA_HOME", jdkFolder);
 				
 			}
 			else if (cluster.ClusterConfiguration.Version >= "7.0.0" && !string.IsNullOrWhiteSpace(javaHome))
 			{
-				cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} [JAVA_HOME] is set, unsetting for process to prefer bundled jdk..");
-				Environment.SetEnvironmentVariable("JAVA_HOME", null);
+				cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} [{envVarName}] is set; clearing value for process to prefer bundled jdk...");
+				Environment.SetEnvironmentVariable(envVarName, null);
 			}
-
-			else cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} JAVA_HOME is set proceeding or using default JDK");
-
+			else cluster.Writer?.WriteDiagnostic($"{{{nameof(EnsureJavaHomeEnvironmentVariableIsSet)}}} {envVarName} is not set proceeding or using default JDK");
 		}
 	}
 }

--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/InstallationTasks/SetElasticsearchBundledJdkJavaHome.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/InstallationTasks/SetElasticsearchBundledJdkJavaHome.cs
@@ -12,13 +12,13 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks.InstallationTasks
 	{
 		public override void Run(IEphemeralCluster<EphemeralClusterConfiguration> cluster)
 		{
-			
 			var fs = cluster.FileSystem;
 			var jdkFolder = Path.Combine(fs.ElasticsearchHome, "jdk");
 			if (Directory.Exists(jdkFolder))
 			{
-				cluster.Writer?.WriteDiagnostic($"{{{nameof(SetElasticsearchBundledJdkJavaHome)}}} [JAVA_HOME] is set to bundled jdk: {{{jdkFolder}}} ");
-				Environment.SetEnvironmentVariable("JAVA_HOME", jdkFolder);
+				var envVarName = cluster.ClusterConfiguration.JavaHomeEnvironmentVariable;
+				cluster.Writer?.WriteDiagnostic($"{{{nameof(SetElasticsearchBundledJdkJavaHome)}}} [{envVarName}] is set to bundled jdk: {{{jdkFolder}}} ");
+				Environment.SetEnvironmentVariable(envVarName, jdkFolder);
 			}
 			else 
 				cluster.Writer?.WriteDiagnostic($"{{{nameof(SetElasticsearchBundledJdkJavaHome)}}} [No bundled jdk found] looked in: {{{jdkFolder}}} ");

--- a/src/Elastic.Elasticsearch.Managed/Configuration/ClusterConfiguration.cs
+++ b/src/Elastic.Elasticsearch.Managed/Configuration/ClusterConfiguration.cs
@@ -82,6 +82,7 @@ namespace Elastic.Elasticsearch.Managed.Configuration
 		public int StartingPortNumber { get; set; } = 9200;
 		public bool NoCleanupAfterNodeStopped { get; set; }
 
+		public string JavaHomeEnvironmentVariable => Version.InRange("<7.12.0") ? "JAVA_HOME" : "ES_JAVA_HOME";
 
 		/// <summary> Will print the contents of all the yaml files when starting the cluster up, great for debugging purposes</summary>
 		public bool PrintYamlFilesInConfigFolder { get; set; }

--- a/src/Elastic.Elasticsearch.Managed/ElasticsearchNode.cs
+++ b/src/Elastic.Elasticsearch.Managed/ElasticsearchNode.cs
@@ -107,9 +107,10 @@ namespace Elastic.Elasticsearch.Managed
 			writer?.WriteDiagnostic($"Elasticsearch location: [{Binary}]", node);
 			writer?.WriteDiagnostic($"Settings: {{{string.Join(" ", NodeConfiguration.CommandLineArguments)}}}", node);
 
-			var javaHome = Environment.GetEnvironmentVariable("JAVA_HOME");
-			writer?.WriteDiagnostic($"JAVA_HOME: {{{javaHome}}}", node);
-			Process.StartInfo.Environment["JAVA_HOME"] = javaHome;
+			var envVarName = NodeConfiguration.Version.InRange("<7.12.0") ? "JAVA_HOME" : "ES_JAVA_HOME";
+			var javaHome = Environment.GetEnvironmentVariable(envVarName);
+			writer?.WriteDiagnostic($"{envVarName}: {{{javaHome}}}", node);
+			Process.StartInfo.Environment[envVarName] = javaHome;
 
 			return SubscribeLines(
 				l => {


### PR DESCRIPTION
This supports conditionally using the preferred ES_JAVA_HOME environment variable when the cluster version is 7.12.0 or higher. This also fixes an issue where the adduser command fails when using XPack on 7.12.0 or higher. When running on 7.12.0, a deprecation warning is printed to stdout which incorrectly triggered an exception in our code. I have specifically excluded this warning from triggering an error, although it should no longer appear since we'll use the most appropriate env var name.

I also fixed a couple of typos when I spotted them. 😄 