### PR TITLE
Handle alpha versions correctly

### DIFF
--- a/src/Elastic.Elasticsearch.Managed/ClusterBase.cs
+++ b/src/Elastic.Elasticsearch.Managed/ClusterBase.cs
@@ -118,7 +118,7 @@ namespace Elastic.Elasticsearch.Managed
 			if (!Started)
 			{
 				var nodeExceptions = Nodes.Select(n => n.LastSeenException).Where(e => e != null).ToList();
-				var message = $"{{{GetType().Name}.{nameof(Start)}}} cluster did not start succesfully";
+				var message = $"{{{GetType().Name}.{nameof(Start)}}} cluster did not start successfully";
 				var seeLogsMessage = SeeLogsMessage(message);
 				writer?.WriteError(seeLogsMessage);
 				throw new AggregateException(seeLogsMessage, nodeExceptions);

--- a/src/Elastic.Stack.ArtifactsApi/ElasticVersion.cs
+++ b/src/Elastic.Stack.ArtifactsApi/ElasticVersion.cs
@@ -14,8 +14,7 @@ namespace Elastic.Stack.ArtifactsApi
 {
 	public class ElasticVersion : Version, IComparable<string>
 	{
-		private readonly ConcurrentDictionary<string, Artifact>
-			_resolved = new ConcurrentDictionary<string, Artifact>();
+		private readonly ConcurrentDictionary<string, Artifact> _resolved = new();
 
 		protected ElasticVersion(string version, ArtifactBuildState state, string buildHash = null) : base(version)
 		{
@@ -73,7 +72,8 @@ namespace Elastic.Stack.ArtifactsApi
 						: ArtifactBuildState.BuildCandidate;
 			}
 
-			if (string.IsNullOrWhiteSpace(managedVersionString)) return null;
+			if (string.IsNullOrWhiteSpace(managedVersionString))
+				return null;
 
 			var version = managedVersionString;
 			var state = GetReleaseState(version);
@@ -88,8 +88,10 @@ namespace Elastic.Stack.ArtifactsApi
 					if (state == ArtifactBuildState.BuildCandidate)
 						buildHash = ApiResolver.LatestBuildHash(version);
 					break;
+				// When the version is not yet released but contains the alpha label, we treat it in the same way as snapshots so it is resolved correctly
 				case { } _ when managedVersionString.EndsWith("-snapshot", StringComparison.OrdinalIgnoreCase)
-				                || managedVersionString.IndexOf("-alpha", StringComparison.OrdinalIgnoreCase) >= 0:
+				                || state != ArtifactBuildState.Released &&
+				                managedVersionString.IndexOf("-alpha", StringComparison.OrdinalIgnoreCase) >= 0:
 					state = ArtifactBuildState.Snapshot;
 					break;
 				case { } _ when TryParseBuildCandidate(managedVersionString, out var v, out buildHash):
@@ -110,7 +112,8 @@ namespace Elastic.Stack.ArtifactsApi
 			version = null;
 			gitHash = null;
 			var tokens = passedVersion.Split(':');
-			if (tokens.Length < 2) return false;
+			if (tokens.Length < 2)
+				return false;
 			version = tokens[1].Trim();
 			gitHash = tokens[0].Trim();
 			return true;
@@ -125,7 +128,8 @@ namespace Elastic.Stack.ArtifactsApi
 		public bool InRange(Range versionRange)
 		{
 			var satisfied = versionRange.IsSatisfied(this);
-			if (satisfied) return true;
+			if (satisfied)
+				return true;
 
 			//Semver can only match snapshot version with ranges on the same major and minor
 			//anything else fails but we want to know e.g 2.4.5-SNAPSHOT satisfied by <5.0.0;

--- a/src/Elastic.Stack.ArtifactsApi/ElasticVersion.cs
+++ b/src/Elastic.Stack.ArtifactsApi/ElasticVersion.cs
@@ -28,7 +28,7 @@ namespace Elastic.Stack.ArtifactsApi
 
 		public int CompareTo(string other)
 		{
-			var v = (ElasticVersion) other;
+			var v = (ElasticVersion)other;
 			return CompareTo(v);
 		}
 
@@ -81,17 +81,18 @@ namespace Elastic.Stack.ArtifactsApi
 
 			switch (managedVersionString)
 			{
-				case string _ when managedVersionString.StartsWith("latest-", StringComparison.OrdinalIgnoreCase):
+				case { } when managedVersionString.StartsWith("latest-", StringComparison.OrdinalIgnoreCase):
 					var major = int.Parse(managedVersionString.Replace("latest-", ""));
 					version = SnapshotApiResolver.LatestReleaseOrSnapshotForMajor(major).ToString();
 					state = GetReleaseState(version);
 					if (state == ArtifactBuildState.BuildCandidate)
 						buildHash = ApiResolver.LatestBuildHash(version);
 					break;
-				case string _ when managedVersionString.EndsWith("-snapshot", StringComparison.OrdinalIgnoreCase):
+				case { } _ when managedVersionString.EndsWith("-snapshot", StringComparison.OrdinalIgnoreCase)
+				                || managedVersionString.IndexOf("-alpha", StringComparison.OrdinalIgnoreCase) >= 0:
 					state = ArtifactBuildState.Snapshot;
 					break;
-				case string _ when TryParseBuildCandidate(managedVersionString, out var v, out buildHash):
+				case { } _ when TryParseBuildCandidate(managedVersionString, out var v, out buildHash):
 					state = ArtifactBuildState.BuildCandidate;
 					version = v;
 					break;
@@ -135,24 +136,24 @@ namespace Elastic.Stack.ArtifactsApi
 
 		public static implicit operator ElasticVersion(string version) => From(version);
 
-		public static bool operator <(ElasticVersion first, string second) => first < (ElasticVersion) second;
-		public static bool operator >(ElasticVersion first, string second) => first > (ElasticVersion) second;
+		public static bool operator <(ElasticVersion first, string second) => first < (ElasticVersion)second;
+		public static bool operator >(ElasticVersion first, string second) => first > (ElasticVersion)second;
 
-		public static bool operator <(string first, ElasticVersion second) => (ElasticVersion) first < second;
-		public static bool operator >(string first, ElasticVersion second) => (ElasticVersion) first > second;
+		public static bool operator <(string first, ElasticVersion second) => (ElasticVersion)first < second;
+		public static bool operator >(string first, ElasticVersion second) => (ElasticVersion)first > second;
 
-		public static bool operator <=(ElasticVersion first, string second) => first <= (ElasticVersion) second;
-		public static bool operator >=(ElasticVersion first, string second) => first >= (ElasticVersion) second;
+		public static bool operator <=(ElasticVersion first, string second) => first <= (ElasticVersion)second;
+		public static bool operator >=(ElasticVersion first, string second) => first >= (ElasticVersion)second;
 
-		public static bool operator <=(string first, ElasticVersion second) => (ElasticVersion) first <= second;
-		public static bool operator >=(string first, ElasticVersion second) => (ElasticVersion) first >= second;
+		public static bool operator <=(string first, ElasticVersion second) => (ElasticVersion)first <= second;
+		public static bool operator >=(string first, ElasticVersion second) => (ElasticVersion)first >= second;
 
-		public static bool operator ==(ElasticVersion first, string second) => first == (ElasticVersion) second;
-		public static bool operator !=(ElasticVersion first, string second) => first != (ElasticVersion) second;
+		public static bool operator ==(ElasticVersion first, string second) => first == (ElasticVersion)second;
+		public static bool operator !=(ElasticVersion first, string second) => first != (ElasticVersion)second;
 
 
-		public static bool operator ==(string first, ElasticVersion second) => (ElasticVersion) first == second;
-		public static bool operator !=(string first, ElasticVersion second) => (ElasticVersion) first != second;
+		public static bool operator ==(string first, ElasticVersion second) => (ElasticVersion)first == second;
+		public static bool operator !=(string first, ElasticVersion second) => (ElasticVersion)first != second;
 
 		// ReSharper disable once UnusedMember.Local
 		private bool Equals(ElasticVersion other) => base.Equals(other);


### PR DESCRIPTION
The master branch of `elasticsearch-net` is failing to run integration tests due to an inability to locate the artefact for 8.0.0-alpha1. This PR ensures that any versions which include "-alpha" in their version string are treated in the same way as snapshot versions and located correctly.