### PR TITLE
Respond to ES node "started" log message change

### DIFF
--- a/src/Elastic.Elasticsearch.Managed/ConsoleWriters/LineOutParser.cs
+++ b/src/Elastic.Elasticsearch.Managed/ConsoleWriters/LineOutParser.cs
@@ -64,7 +64,7 @@ namespace Elastic.Elasticsearch.Managed.ConsoleWriters
 		private static bool TryGetStartedConfirmation(string section, string message)
 		{
 			var inNodeSection = section == "o.e.n.Node" || section == "node";
-			return inNodeSection && message == "started";
+			return inNodeSection && (message == "started" || message.StartsWith("started {", StringComparison.Ordinal));
 		}
 
 		public static bool TryGetPortNumber(string section, string message, out int port)


### PR DESCRIPTION
A recent [PR](https://github.com/elastic/elasticsearch/pull/85773) in Elasticsearch introduced a subtle change to the log message format for the "started" log message. This is now in an 8.3.0-SNAPSHOT build and causes the nodes to never be recognised as started, ultimately timing out the handling of the managed cluster.

This PR addresses this by updating the check for the started message to also accept those beginning with the new format.