### PR TITLE
Ingest attachment ships in-box from 8.4

### DIFF
--- a/src/Elastic.Stack.ArtifactsApi/Products/ElasticsearchPlugin.cs
+++ b/src/Elastic.Stack.ArtifactsApi/Products/ElasticsearchPlugin.cs
@@ -36,7 +36,10 @@ namespace Elastic.Stack.ArtifactsApi.Products
 		public static ElasticsearchPlugin DiscoveryGCE { get; } = new ElasticsearchPlugin("discovery-gce");
 
 		public static ElasticsearchPlugin IngestAttachment { get; } =
-			new ElasticsearchPlugin("ingest-attachment", version => version >= "5.0.0-alpha3");
+			new ElasticsearchPlugin("ingest-attachment", version => version >= "5.0.0-alpha3")
+			{
+				ShippedByDefaultAsOf = "8.4.0"
+			};
 
 		public static ElasticsearchPlugin IngestGeoIp { get; } =
 			new ElasticsearchPlugin("ingest-geoip", version => version >= "5.0.0-alpha3")


### PR DESCRIPTION
From 8.4, the ingest-attachment is a module included by default and no longer needs to be downloaded and installed as a plugin.