### PR TITLE
Added support for version >= 8.0.0

### DIFF
--- a/src/Elastic.Elasticsearch.Ephemeral/EphemeralFileSystem.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/EphemeralFileSystem.cs
@@ -32,6 +32,7 @@ namespace Elastic.Elasticsearch.Ephemeral
 		public string CertificatesPath => Path.Combine(ConfigPath, CertificateFolderName);
 
 		public string CaCertificate => Path.Combine(CertificatesPath, "ca", "ca") + ".crt";
+		public string CaPrivateKey => Path.Combine(CertificatesPath, "ca", "ca") + ".key";
 
 		public string NodePrivateKey =>
 			Path.Combine(CertificatesPath, CertificateNodeName, CertificateNodeName) + ".key";

--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -185,8 +185,8 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks
 				errorOut = errorOut.Where(e => !e.Line.Contains("No log4j2 configuration file found")).ToList();
 
 			if (errorOut.Any(e =>
-				    !string.IsNullOrWhiteSpace(e.Line) && !e.Line.Contains("usage of JAVA_HOME is deprecated")) &&
-			    !binary.Contains("plugin") && !binary.Contains("cert"))
+				    !string.IsNullOrWhiteSpace(e.Line) && !e.Line.Contains("usage of JAVA_HOME is deprecated") && !e.Line.Contains("using ES_JAVA_HOME")) &&
+			    !binary.Contains("plugin") && !binary.Contains("cert") )
 				throw new Exception(
 					$"Received error out with exitCode ({result.ExitCode}) while executing {description}: {command}");
 


### PR DESCRIPTION
The issue with using version 8 was that elasticsearch-certutil no longer generated a CA automatically. It is now a separate step in the setup. The GenerateCertificatesTask now generates a certificate authority when version 8 detected.

In addition version 8 also produces a slightly different warning message when JAVA_HOME is messing. The ClusterComposeTask ExecuteBinary now also ignores warning lines containing "using ES_JAVA_HOME".