### PR TITLE
Don't error when warnings are written over stderr

### DIFF
--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -184,9 +184,13 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks
 			if (errorOut.Any() && config.Version < "5.2.0")
 				errorOut = errorOut.Where(e => !e.Line.Contains("No log4j2 configuration file found")).ToList();
 
-			if (errorOut.Any(e =>
-				    !string.IsNullOrWhiteSpace(e.Line) && !e.Line.Contains("usage of JAVA_HOME is deprecated")) &&
-			    !binary.Contains("plugin") && !binary.Contains("cert"))
+			errorOut = errorOut
+				.Where(e=> !string.IsNullOrWhiteSpace(e.Line))
+				.Where(e => !e.Line.Contains("usage of JAVA_HOME is deprecated"))
+				.Where(e => !e.Line.StartsWith("warning:"))
+				.ToList();
+
+			if (errorOut.Any() && !binary.Contains("plugin") && !binary.Contains("cert"))
 				throw new Exception(
 					$"Received error out with exitCode ({result.ExitCode}) while executing {description}: {command}");
 

--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -187,7 +187,7 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks
 			errorOut = errorOut
 				.Where(e=> !string.IsNullOrWhiteSpace(e.Line))
 				.Where(e => !e.Line.Contains("usage of JAVA_HOME is deprecated"))
-				.Where(e => !e.Line.StartsWith("warning:"))
+				.Where(e => !e.Line.Trim().StartsWith("warning:"))
 				.ToList();
 
 			if (errorOut.Any() && !binary.Contains("plugin") && !binary.Contains("cert"))

--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -185,7 +185,7 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks
 				errorOut = errorOut.Where(e => !e.Line.Contains("No log4j2 configuration file found")).ToList();
 
 			errorOut = errorOut
-				.Where(e=> !string.IsNullOrWhiteSpace(e.Line))
+				.Where(e => !string.IsNullOrWhiteSpace(e.Line))
 				.Where(e => !e.Line.Contains("usage of JAVA_HOME is deprecated"))
 				.Where(e => !e.Line.Trim().StartsWith("warning:"))
 				.ToList();


### PR DESCRIPTION
Found here:

https://github.com/elastic/elastic-ingest-dotnet/actions/runs/5414752220/jobs/9842253506?pr=38#step:6:1559

Where the ci environment has a JAVA_HOME and bootstrapping users fails because the command line tooling writes a warning over standard error:

> warning: ignoring JAVA_HOME=/usr/lib/jvm/temurin-11-jdk-amd64; using ES_JAVA_HOME