### PR TITLE
AutoWire detected proxies during setup

### DIFF
--- a/examples/Elastic.Ephemeral.Example/Elastic.Ephemeral.Example.csproj
+++ b/examples/Elastic.Ephemeral.Example/Elastic.Ephemeral.Example.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elastic.Elasticsearch.Ephemeral\Elastic.Elasticsearch.Ephemeral.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.Elasticsearch.Ephemeral\Elastic.Elasticsearch.Ephemeral.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elastic.Transport" Version="0.4.12" />
   </ItemGroup>
 
 </Project>

--- a/examples/Elastic.Ephemeral.Example/Program.cs
+++ b/examples/Elastic.Ephemeral.Example/Program.cs
@@ -3,7 +3,12 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Elasticsearch.Ephemeral;
+using Elastic.Elasticsearch.Managed;
+using Elastic.Transport;
+using Elastic.Transport.Products.Elasticsearch;
+using static Elastic.Elasticsearch.Ephemeral.ClusterAuthentication;
 using static Elastic.Elasticsearch.Ephemeral.ClusterFeatures;
+using HttpMethod = Elastic.Transport.HttpMethod;
 
 
 var config = new EphemeralClusterConfiguration("8.7.0", XPack | Security | SSL);
@@ -16,4 +21,18 @@ Console.CancelKeyPress += (sender, eventArgs) => {
 	exitEvent.Set();
 };
 using var started = cluster.Start();
+
+var pool = new StaticNodePool(cluster.NodesUris());
+var transportConfig = new TransportConfiguration(pool, productRegistration: ElasticsearchProductRegistration.Default)
+	.Authentication(new BasicAuthentication(Admin.Username, Admin.Password))
+	.ServerCertificateValidationCallback(CertificateValidations.AllowAll);
+if (cluster.DetectedProxy != DetectedProxySoftware.None)
+	transportConfig = transportConfig.Proxy(new Uri("http://localhost:8080"), null!, null!);
+
+var transport = new DefaultHttpTransport(transportConfig);
+
+var response = await transport.RequestAsync<StringResponse>(HttpMethod.GET, "/");
+Console.WriteLine(response);
+
+
 exitEvent.WaitOne();

--- a/examples/ScratchPad/Program.cs
+++ b/examples/ScratchPad/Program.cs
@@ -39,7 +39,7 @@ namespace ScratchPad
 			var features = Security | XPack | SSL;
 			var config = new EphemeralClusterConfiguration(version, features, plugins, 1)
 			{
-				HttpFiddlerAware = true,
+				AutoWireKnownProxies = true,
 				ShowElasticsearchOutputAfterStarted = true,
 				CacheEsHomeInstallation = false,
 				TrialMode = XPackTrialMode.Trial,

--- a/examples/ScratchPad/ValidateCombinations.cs
+++ b/examples/ScratchPad/ValidateCombinations.cs
@@ -38,7 +38,7 @@ namespace ScratchPad
 				Console.WriteLine($"{v} {f}");
 
 				Console.ForegroundColor = reset;
-				var config = new EphemeralClusterConfiguration(v, f, plugins, 1) {HttpFiddlerAware = true,};
+				var config = new EphemeralClusterConfiguration(v, f, plugins, 1) {AutoWireKnownProxies = true,};
 
 				using (var cluster = new EphemeralCluster(config))
 					try

--- a/src/Elastic.Elasticsearch.Ephemeral/EphemeralCluster.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/EphemeralCluster.cs
@@ -37,9 +37,13 @@ namespace Elastic.Elasticsearch.Ephemeral
 
 		public virtual ICollection<Uri> NodesUris(string hostName = null)
 		{
-			hostName = hostName ?? (ClusterConfiguration.HttpFiddlerAware && Process.GetProcessesByName("fiddler").Any()
-				? "ipv4.fiddler"
-				: "localhost");
+			hostName ??= "localhost";
+			if (hostName == "localhost" && ClusterConfiguration.AutoWireKnownProxies)
+			{
+				if (DetectedProxy == DetectedProxySoftware.Fiddler)
+					hostName = "ipv4.fiddler"; //magic reverse proxy address for fiddler
+			}
+
 			var ssl = ClusterConfiguration.EnableSsl ? "s" : "";
 			return Nodes
 				.Select(n => $"http{ssl}://{hostName}:{n.Port ?? 9200}")

--- a/src/Elastic.Elasticsearch.Ephemeral/EphemeralClusterConfiguration.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/EphemeralClusterConfiguration.cs
@@ -89,8 +89,14 @@ namespace Elastic.Elasticsearch.Ephemeral
 		/// </summary>
 		public XPackTrialMode TrialMode { get; set; }
 
-		/// <summary> Bootstrapping HTTP calls should attempt to auto route traffic through fiddler if its running </summary>
-		public bool HttpFiddlerAware { get; set; }
+		/// <summary>
+		/// Bootstrapping HTTP calls should attempt to auto route traffic through known proxy software if they are running
+		/// <list type="buller">
+		/// <item> <description>Fiddler, typically on Windows</description></item>
+		/// <item> <description>mitmproxy, typically on non Windows OS's</description></item>
+		/// </list>
+		/// </summary>
+		public bool AutoWireKnownProxies { get; set; }
 
 		protected virtual string NodePrefix => "ephemeral";
 

--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/InstallationTasks/PrintConfiguration.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/InstallationTasks/PrintConfiguration.cs
@@ -50,7 +50,7 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks.InstallationTasks
 			cluster.Writer?.WriteDiagnostic(
 				$"{{{nameof(PrintConfiguration)}}} {{{nameof(c.SkipBuiltInAfterStartTasks)}}} [{c.SkipBuiltInAfterStartTasks}]");
 			cluster.Writer?.WriteDiagnostic(
-				$"{{{nameof(PrintConfiguration)}}} {{{nameof(c.HttpFiddlerAware)}}} [{c.HttpFiddlerAware}]");
+				$"{{{nameof(PrintConfiguration)}}} {{{nameof(c.AutoWireKnownProxies)}}} [{c.AutoWireKnownProxies}]");
 			cluster.Writer?.WriteDiagnostic(
 				$"{{{nameof(PrintConfiguration)}}} {{{nameof(c.NoCleanupAfterNodeStopped)}}} [{c.NoCleanupAfterNodeStopped}]");
 		}

--- a/src/Elastic.Elasticsearch.Managed/ClusterBase.cs
+++ b/src/Elastic.Elasticsearch.Managed/ClusterBase.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -12,6 +13,7 @@ using Elastic.Elasticsearch.Managed.Configuration;
 using Elastic.Elasticsearch.Managed.ConsoleWriters;
 using Elastic.Elasticsearch.Managed.FileSystem;
 using ProcNet.Std;
+using static Elastic.Elasticsearch.Managed.DetectedProxySoftware;
 
 namespace Elastic.Elasticsearch.Managed
 {
@@ -30,6 +32,11 @@ namespace Elastic.Elasticsearch.Managed
 		IDisposable Start(TimeSpan waitForStarted);
 
 		IDisposable Start(IConsoleLineHandler writer, TimeSpan waitForStarted);
+
+		/// <summary>
+		/// Whether known proxies were detected as running during startup
+		/// </summary>
+		DetectedProxySoftware DetectedProxy { get; }
 	}
 
 
@@ -75,7 +82,17 @@ namespace Elastic.Elasticsearch.Managed
 				node.NodeConfiguration.InitialMasterNodes(initialMasterNodes);
 
 			Nodes = new ReadOnlyCollection<ElasticsearchNode>(nodes);
+
+			if (Process.GetProcessesByName("fiddler").Any()) DetectedProxy = Fiddler;
+			else if (Process.GetProcessesByName("mitmproxy").Any()) DetectedProxy = MitmProxy;
+			else DetectedProxy = None;
 		}
+
+		/// <summary>
+		/// Whether known proxies were detected as running during startup
+		/// </summary>
+		public DetectedProxySoftware DetectedProxy { get; }
+
 
 		/// <summary>
 		///     A short name to identify the cluster defaults to the <see cref="ClusterBase" /> subclass name with Cluster

--- a/src/Elastic.Elasticsearch.Managed/Configuration/ClusterConfiguration.cs
+++ b/src/Elastic.Elasticsearch.Managed/Configuration/ClusterConfiguration.cs
@@ -80,6 +80,7 @@ namespace Elastic.Elasticsearch.Managed.Configuration
 			if (logsPathDefault != fs.LogsPath) Add("path.logs", fs.LogsPath);
 
 			if (version.Major < 6) Add("path.conf", fs.ConfigPath);
+
 		}
 
 		public Artifact Artifact { get; }

--- a/src/Elastic.Elasticsearch.Managed/DetectedProxySoftware.cs
+++ b/src/Elastic.Elasticsearch.Managed/DetectedProxySoftware.cs
@@ -1,0 +1,8 @@
+namespace Elastic.Elasticsearch.Managed;
+
+public enum DetectedProxySoftware
+{
+	None, 
+	Fiddler, 
+	MitmProxy
+}

--- a/src/Elastic.Elasticsearch.Managed/DetectedProxySoftware.cs
+++ b/src/Elastic.Elasticsearch.Managed/DetectedProxySoftware.cs
@@ -1,8 +1,12 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 namespace Elastic.Elasticsearch.Managed;
 
 public enum DetectedProxySoftware
 {
-	None, 
-	Fiddler, 
+	None,
+	Fiddler,
 	MitmProxy
 }


### PR DESCRIPTION
And expose if we detected a proxy running this makes it easier
to see what is happening over the wire during development by
simply running `fiddler` or `mitmproxy`

This does require `mitmproxy` is not installed through `brew install mitmproxy`
but the actual binaries are used.
