### PR TITLE
Ensure IEphemeralCluster extends ICluster

### DIFF
--- a/src/Elastic.Elasticsearch.Ephemeral/IEphemeralCluster.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/IEphemeralCluster.cs
@@ -8,7 +8,7 @@ using Elastic.Elasticsearch.Managed;
 
 namespace Elastic.Elasticsearch.Ephemeral
 {
-	public interface IEphemeralCluster
+	public interface IEphemeralCluster : ICluster
 	{
 		ICollection<Uri> NodesUris(string hostName = null);
 		string GetCacheFolderName();

--- a/src/Elastic.Elasticsearch.Managed/ClusterBase.cs
+++ b/src/Elastic.Elasticsearch.Managed/ClusterBase.cs
@@ -17,14 +17,32 @@ using static Elastic.Elasticsearch.Managed.DetectedProxySoftware;
 
 namespace Elastic.Elasticsearch.Managed
 {
-	public interface ICluster<out TConfiguration> : IDisposable
+	public interface ICluster
+	{
+		/// <summary>
+		/// Whether known proxies were detected as running during startup
+		/// </summary>
+		DetectedProxySoftware DetectedProxy { get; }
+
+		/// <summary> A friendly name for this cluster, derived from the implementation name</summary>
+		string ClusterMoniker { get; }
+
+		/// <inheritdoc cref="INodeFileSystem"/>
+		INodeFileSystem FileSystem { get; }
+
+		/// <summary> Indicating if this cluster was started correctly </summary>
+		bool Started { get; }
+
+		/// <summary>
+		/// The collection of <see cref="ElasticsearchNode"/>'s that make up the cluster
+		/// </summary>
+		ReadOnlyCollection<ElasticsearchNode> Nodes { get; }
+	}
+
+	public interface ICluster<out TConfiguration> : ICluster,IDisposable
 		where TConfiguration : IClusterConfiguration<NodeFileSystem>
 	{
-		string ClusterMoniker { get; }
 		TConfiguration ClusterConfiguration { get; }
-		INodeFileSystem FileSystem { get; }
-		bool Started { get; }
-		ReadOnlyCollection<ElasticsearchNode> Nodes { get; }
 		IConsoleLineHandler Writer { get; }
 
 		IDisposable Start();
@@ -32,11 +50,6 @@ namespace Elastic.Elasticsearch.Managed
 		IDisposable Start(TimeSpan waitForStarted);
 
 		IDisposable Start(IConsoleLineHandler writer, TimeSpan waitForStarted);
-
-		/// <summary>
-		/// Whether known proxies were detected as running during startup
-		/// </summary>
-		DetectedProxySoftware DetectedProxy { get; }
 	}
 
 

--- a/src/Elastic.Elasticsearch.Xunit/XunitClusterExtensions.cs
+++ b/src/Elastic.Elasticsearch.Xunit/XunitClusterExtensions.cs
@@ -13,8 +13,7 @@ namespace Elastic.Elasticsearch.Xunit
 	/// </summary>
 	public static class XunitClusterExtensions
 	{
-		private static readonly ConcurrentDictionary<IEphemeralCluster, object> Clients =
-			new ConcurrentDictionary<IEphemeralCluster, object>();
+		private static readonly ConcurrentDictionary<IEphemeralCluster, object> Clients = new();
 
 		/// <summary>
 		///     Gets a client for the cluster if one exists, or creates a new client if one doesn't.


### PR DESCRIPTION
Which is a new base interface also for ICluster<TConfiguration>

This makes `GetOrAddClient` a lot more capable of determining how to best build the client
