### PR TITLE
Update Proc package and simplify binary execution logic

### DIFF
--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.0.0" />
     <PackageReference Include="Bullseye" Version="3.3.0" />
-    <PackageReference Include="Proc" Version="0.6.2" />
+    <PackageReference Include="Proc" Version="0.8.2" />
     <PackageReference Include="Fake.Tools.Git" Version="5.15.0" />
   </ItemGroup>
 

--- a/examples/ScratchPad/ScratchPad.csproj
+++ b/examples/ScratchPad/ScratchPad.csproj
@@ -5,7 +5,7 @@
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Proc" Version="0.6.1" />
+    <PackageReference Include="Proc" Version="0.8.2" />
     <!--<ProjectReference Include="..\..\..\..\..\proc\src\Proc\Proc.csproj" />-->
     <PackageReference Include="NEST" Version="6.0.1" />
   </ItemGroup>

--- a/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Elasticsearch.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -148,14 +148,10 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks
 
 		protected static void ExecuteBinary(EphemeralClusterConfiguration config, IConsoleLineHandler writer,
 			string binary, string description, params string[] arguments) =>
-			ExecuteBinaryInternal(config, writer, binary, description, null, arguments);
-
-		protected static void ExecuteBinary(EphemeralClusterConfiguration config, IConsoleLineHandler writer,
-			string binary, string description, StartedHandler startedHandler, params string[] arguments) =>
-			ExecuteBinaryInternal(config, writer, binary, description, startedHandler, arguments);
+			ExecuteBinaryInternal(config, writer, binary, description, arguments);
 
 		private static void ExecuteBinaryInternal(EphemeralClusterConfiguration config, IConsoleLineHandler writer,
-			string binary, string description, StartedHandler startedHandler, params string[] arguments)
+			string binary, string description, params string[] arguments)
 		{
 			var command = $"{{{binary}}} {{{string.Join(" ", arguments)}}}";
 			writer?.WriteDiagnostic($"{{{nameof(ExecuteBinary)}}} starting process [{description}] {command}");
@@ -170,9 +166,7 @@ namespace Elastic.Elasticsearch.Ephemeral.Tasks
 				}
 			};
 
-			var result = startedHandler != null
-				? Proc.Start(processStartArguments, timeout, new ConsoleOutColorWriter(), startedHandler)
-				: Proc.Start(processStartArguments, timeout, new ConsoleOutColorWriter());
+			var result = Proc.Start(processStartArguments, timeout, new ConsoleOutColorWriter());
 
 			if (!result.Completed)
 				throw new Exception($"Timeout while executing {description} exceeded {timeout}");

--- a/src/Elastic.Elasticsearch.Managed/Elastic.Elasticsearch.Managed.csproj
+++ b/src/Elastic.Elasticsearch.Managed/Elastic.Elasticsearch.Managed.csproj
@@ -9,7 +9,7 @@
     <PackageTags>elastic,elasticsearch,cluster,observable,rx</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Proc" Version="0.6.1" />
+    <PackageReference Include="Proc" Version="0.8.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Stack.ArtifactsApi\Elastic.Stack.ArtifactsApi.csproj" />


### PR DESCRIPTION
Upgraded Proc package references from various older versions to 0.8.2 across multiple projects for consistency. Removed redundant overloaded method in `IClusterComposeTask.cs` to streamline the binary execution logic.
